### PR TITLE
Release v0.902.1+0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,21 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
 
 [[package]]
 name = "ahash"
@@ -110,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,21 +131,6 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "base64"
@@ -160,15 +156,12 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lazycell",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -221,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -238,11 +231,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
-name = "cc"
-version = "1.1.35"
+name = "bzip2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -272,7 +277,17 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.0",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -302,10 +317,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -324,6 +355,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -372,12 +427,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
+name = "deflate64"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -388,6 +460,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -466,19 +539,35 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "fnv"
@@ -602,12 +691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,9 +698,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -645,24 +728,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "home"
-version = "0.5.9"
+name = "hmac"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "windows-sys 0.52.0",
+ "digest",
 ]
 
 [[package]]
@@ -707,13 +784,14 @@ checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -727,11 +805,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -760,21 +837,27 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -956,10 +1039,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -983,12 +1085,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "js-sys"
-version = "0.3.72"
+name = "jobserver"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-spanned-value"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb343fa4e3b1b22b344937deedac88da995abf139c2232cbeaa436c38380a210"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1004,10 +1126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "libc"
-version = "0.2.161"
+name = "libbz2-rs-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -1031,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1043,17 +1171,24 @@ checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
 dependencies = [
- "twox-hash",
+ "crc",
+ "sha2",
 ]
 
 [[package]]
@@ -1085,30 +1220,30 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1157,15 +1292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,9 +1299,9 @@ checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1199,15 +1325,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -1226,6 +1352,16 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1247,9 +1383,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "powerfmt"
@@ -1258,22 +1394,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -1291,9 +1423,7 @@ version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
- "encoding_rs",
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1346,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "raxb"
-version = "0.4.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ccfd0ed501beb005356fdf14c1bf82226a31275fcab063c0a55ff210de1987"
+checksum = "0e7753b2543fdc9e8a24889f4dd9d3299824bd196936c86a4f2adefff932cbd6"
 dependencies = [
  "quick-xml",
  "raxb-derive",
@@ -1358,11 +1488,10 @@ dependencies = [
 
 [[package]]
 name = "raxb-derive"
-version = "0.4.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59478a86de24ef5ae2c53b9501c6eb81143ca940ed34324f6b00fa072d79e96a"
+checksum = "4427d2c9c8b1d8d632dbb1dc250e66dbc7a5b507f3c3076f8933e74c7cdb6384"
 dependencies = [
- "darling",
  "heck",
  "proc-macro2",
  "quick-xml",
@@ -1373,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "raxb-libxml2-sys"
-version = "0.4.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d64a0805542f8b659a305a498e2db854c94321ddb80d293ec6c1b1a14ea1250"
+checksum = "45bca83fe5f7c45195c7f7ea3a058d4b53144c8983f0a878eb051391cfa43009"
 dependencies = [
  "bindgen",
  "cmake",
@@ -1383,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "raxb-validate"
-version = "0.4.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8011ed6e933cc6c99ed8305a0371a88b567704fb607ead59c538d1266139aee"
+checksum = "6d16a81ce997e098b4a623577c65ba61644183eaf911dfdd1f10ed3b4a3b80ff"
 dependencies = [
  "byteorder",
  "libc",
@@ -1401,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "raxb-xmlschema"
-version = "0.4.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5db82cdf77a5da640d3b13621c387618b5886a728cb28add9ffeb769662326"
+checksum = "d75d57e822ab48b5f212710d0d587eb4d861ddcbb78aad43bda0e3bc7c3f2011"
 dependencies = [
  "byteorder",
  "lz4_flex",
@@ -1415,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "raxb-xmlschema-build"
-version = "0.4.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ba2c191266fb3673d423f3faa2f19b4b7ac426a03f2faf4f9e083d24d92756"
+checksum = "a9dc52311dcaf534685388dba07c2afc06ac09cdf26258d10e791010d5e3daee"
 dependencies = [
  "byteorder",
  "raxb",
@@ -1482,9 +1611,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1500,41 +1629,38 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -1575,12 +1701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,22 +1708,22 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1613,25 +1733,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-pki-types"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "rustls-pki-types",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
-
-[[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1661,21 +1775,21 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1683,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1768,6 +1882,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,9 +1900,9 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1809,6 +1934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,31 +1956,19 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1937,12 +2056,12 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1964,12 +2083,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2029,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -2044,15 +2163,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2097,17 +2216,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2122,20 +2240,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2143,6 +2260,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -2157,19 +2313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2238,16 +2382,6 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
 ]
 
 [[package]]
@@ -2472,18 +2606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,33 +2652,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
+ "windows-link 0.2.1",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2584,6 +2711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2738,8 +2874,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "xflags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9e15fbb3de55454b0106e314b28e671279009b363e6f1d8e39fdc3bf048944"
+dependencies = [
+ "xflags-macros",
+]
+
+[[package]]
+name = "xflags-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672423d4fea7ffa2f6c25ba60031ea13dc6258070556f125cc4d790007d4a155"
+
+[[package]]
 name = "xoev-xwasser"
-version = "0.902.0+0.9.2"
+version = "0.902.1+0.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2766,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "xoev-xwasser-codelists"
-version = "0.902.0+0.9.2"
+version = "0.902.1+0.9.2"
 dependencies = [
  "anyhow",
  "bson",
@@ -2780,13 +2931,26 @@ dependencies = [
 
 [[package]]
 name = "xoev-xwasser-derive"
-version = "0.902.0+0.9.2"
+version = "0.902.1+0.9.2"
 dependencies = [
  "darling",
  "heck",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "xtask"
+version = "0.902.1+0.9.2"
+dependencies = [
+ "encoding_rs",
+ "json-spanned-value",
+ "raxb",
+ "reqwest",
+ "serde",
+ "xflags",
+ "zip",
 ]
 
 [[package]]
@@ -2857,9 +3021,23 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerovec"
@@ -2881,4 +3059,77 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.1",
+ "hmac",
+ "indexmap",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 resolver = "3"
-members = ["crates/*"]
+members = ["crates/*", "xtask"]
 
 [workspace.package]
 edition = "2021"
-version = "0.902.0+0.9.2"
+version = "0.902.1+0.9.2"
 description = """
 XOEV XWasser XML Standard
 """
@@ -17,16 +17,13 @@ keywords = []
 
 [workspace.dependencies]
 anyhow = "1.0.97"
-xoev-xwasser-codelists = { version = "0.902.0", path = "crates/codelists" }
-xoev-xwasser-derive = { version = "0.902.0", path = "crates/derive" }
-raxb = "0.4.7"
-raxb-validate = "0.4.7"
-raxb-xmlschema = "0.4.7"
-raxb-xmlschema-build = "0.4.7"
-# raxb = { path = "../raxb/crates/raxb" }
-# raxb-validate = { path = "../raxb/crates/raxb-validate"}
-# raxb-xmlschema = { path = "../raxb/crates/raxb-xmlschema"}
-# raxb-xmlschema-build = { path = "../raxb/crates/raxb-xmlschema-build"}
+encoding_rs = "0.8.35"
+xoev-xwasser-codelists = { version = "0.902.1", path = "crates/codelists" }
+xoev-xwasser-derive = { version = "0.902.1", path = "crates/derive" }
+raxb = "0.6.0"
+raxb-validate = "0.6.0"
+raxb-xmlschema = "0.6.0"
+raxb-xmlschema-build = "0.6.0"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 
 [package]

--- a/tests/monitoring_plan_builder.json
+++ b/tests/monitoring_plan_builder.json
@@ -5,13 +5,13 @@
   "test": true,
   "nachrichtenkopf_g2g": {
     "identifikation_nachricht": {
-      "nachrichten_uuid": "a9945930-e958-4c3c-a1eb-067cdde2b7d9",
+      "nachrichten_uuid": "54aa24ad-3035-43c4-842e-a963da3a5e33",
       "nachrichten_typ": {
         "code": {
           "code": "2010"
         }
       },
-      "erstellungszeitpunkt": "2025-07-15T15:50:55"
+      "erstellungszeitpunkt": "2026-04-15T23:16:41"
     },
     "leser": {
       "verzeichnisdienst": {
@@ -37,14 +37,14 @@
   },
   "vorgang": {
     "identifikation_vorgang": {
-      "vorgangs_id": "fb3f24d2-b17e-4334-9464-c9a7126baef5"
+      "vorgangs_id": "9a95024a-f21e-4a3f-9ff8-5e426301dfce"
     },
     "vorgang_type": {
       "t": "Untersuchungsplan",
       "c": {
-        "untersuchungsplan_id": "6aa6b6ab-1027-4557-aef0-8448a2d69108",
+        "untersuchungsplan_id": "e8a199d9-9c75-46cf-b609-54a1772349f4",
         "wasserversorgungsgebiet": [
-          "wvg-DZScU5Js"
+          "wvg-7DFB4lhq"
         ],
         "titel_untersuchungsplan": null,
         "jahr": [
@@ -95,10 +95,10 @@
         },
         "terminplan": [
           {
-            "terminplan_id": "113bd18b-8167-4799-9d5c-f51052ce1810",
+            "terminplan_id": "1e1a1bfc-0eaf-4909-bb1d-19f9ccebc59c",
             "probennahmestelle": null,
             "datum_zeitraum": [
-              "2025-07-15T15:50:55"
+              "2026-04-15T23:16:41"
             ],
             "probennahmestelle_kategorie": {
               "code": "L",
@@ -131,12 +131,12 @@
             "probennahmeverfahren": [],
             "ersatz_fuer_terminplan_mit_der_id": null,
             "kommentar": null,
-            "id": "terminplan-BFZvJbI1"
+            "id": "terminplan-5xFY3x6v"
           }
         ],
         "anlage_nach_trinkw_v": {
           "anlage_nach_trinkw_v_id": "",
-          "zustaendige_behoerde_id": "behoerde-A3q7ZLWV",
+          "zustaendige_behoerde_id": "behoerde-4xc4JXTM",
           "untersuchungsplan_id": [],
           "art_anlage": {
             "code": "1010",
@@ -148,12 +148,12 @@
           "kommentar": null,
           "wasserversorgungsgebiet": [
             {
-              "wasserversorgungsgebiet_id": "f5a860e6-9335-41a7-837d-004a5da59597",
+              "wasserversorgungsgebiet_id": "5e51ab82-0144-4124-88b1-3dbd6767e215",
               "name_wasserversorgungsgebiet": "",
               "lau2_code": null,
               "zustaendige_behoerde": [
                 {
-                  "id": "behoerde-CjN3h6jE",
+                  "id": "behoerde-6z8PdMrC",
                   "typ": {
                     "code": "",
                     "name": null,
@@ -193,7 +193,7 @@
                 }
               ],
               "geokoordinaten_shapth": null,
-              "datum_der_einrichtung": "2025-07-15",
+              "datum_der_einrichtung": "2026-04-15",
               "datum_der_schliessung": null,
               "grund_der_schliessung": null,
               "nachfolger_wvg_bei_schliessung": [],
@@ -216,15 +216,15 @@
               "derogation": [],
               "exceedance": [],
               "incident": [],
-              "id": "wvg-DZScU5Js"
+              "id": "wvg-7DFB4lhq"
             }
           ],
           "angaben_alternative_id": null,
-          "id": "antv-EHkxPl87"
+          "id": "antv-8JksuBeT"
         },
         "objekt": [
           {
-            "objekt_id": "48abb680-1e38-4088-8739-9f401644fc54",
+            "objekt_id": "db31f13a-19db-43f1-b8cf-fef7a94a0672",
             "anlage_nach_trinkw_vid": null,
             "wasserversorgungsgebiet_id": null,
             "anschrift_objekt": [],
@@ -237,23 +237,16 @@
             "datum_in_betriebnahme": null,
             "datum_ausser_betriebnahme": null,
             "rahmen_der_trinkwasserbereitstellung": [],
-            "geokoordinaten_objekt": {
-              "geografische_position_und_ausdehnung": null,
-              "name_shapefile": null,
-              "geokoordinaten_breitengrad": null,
-              "geokoordinaten_laengengrad": null,
-              "geokoordinaten_rechtswert_east_wert": null,
-              "geokoordinaten_hochwert_north_wert": null
-            },
+            "geokoordinaten_objekt": null,
             "angaben_alternative_id": null,
             "kommentar": null,
             "betreiber": [
               {
-                "betreiber_id": "fcbd6800-86fe-4a63-9268-8efc5132675c",
+                "betreiber_id": "d45d006b-18ad-4b31-a614-e804e77521fd",
                 "art_der_person": {
                   "t": "Organisation",
                   "c": {
-                    "id": "organisation-H1sno4Ss",
+                    "id": "organisation-bdKDjiKk",
                     "rechtsform": null,
                     "branche": [],
                     "zweck": [],
@@ -267,18 +260,18 @@
                   }
                 },
                 "objekt_id": [
-                  "obj-GdyIrJbT"
+                  "obj-a1jw42pC"
                 ],
                 "kommentar": null,
-                "id": "betreiber-IRXPEiep"
+                "id": "betreiber-crzDN2CJ"
               }
             ],
-            "id": "obj-GdyIrJbT"
+            "id": "obj-a1jw42pC"
           }
         ],
         "probennahmestelle": [
           {
-            "probennahmestelle_id": "76bf132d-f645-445c-9628-6532ae30677d",
+            "probennahmestelle_id": "b1cdc034-1ce4-45ae-84e8-f28a6dd357e9",
             "objekt_id": null,
             "wasserversorgungsgebiet_id": null,
             "probe": [],
@@ -307,7 +300,7 @@
             "angaben_alternative_id": null,
             "berichtspflichtig": null,
             "kommentar": null,
-            "id": "probennahmestelle-JJ9kQ334"
+            "id": "probennahmestelle-dHQhhLYR"
           }
         ],
         "auftraggeber": {
@@ -319,7 +312,7 @@
           "auftraggeber": {
             "t": "Organisation",
             "c": {
-              "id": "organisation-FrcLps3A",
+              "id": "organisation-9RbDBHIg",
               "rechtsform": null,
               "branche": [],
               "zweck": [],
@@ -334,7 +327,7 @@
           }
         },
         "zustaendige_behoerde": {
-          "id": "behoerde-A3q7ZLWV",
+          "id": "behoerde-4xc4JXTM",
           "typ": {
             "code": "",
             "name": null,
@@ -382,7 +375,7 @@
         "kommentar": [],
         "aenderungshistorie": null,
         "erweiterung": null,
-        "id": "untersuchungsplan-KD5c0com"
+        "id": "untersuchungsplan-eZDu3rMJ"
       }
     },
     "bemerkung": null,

--- a/tests/monitoring_plan_builder_test_result.xml
+++ b/tests/monitoring_plan_builder_test_result.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<xwas:vorgang.transportieren.2010 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/ ../schemas/V0_9_2/xwasser.xsd" xmlns:xwas="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/" produkt="XWasser Test" produkthersteller="H&amp;amp;D GmbH" produktversion="0.901.0" standard="XWasser" test="true" version="0.9.2">
+<xwas:vorgang.transportieren.2010 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/ ../schemas/V0_9_2/xwasser.xsd" xmlns:xwas="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/" produkt="XWasser Test" produkthersteller="H&amp;D GmbH" produktversion="0.901.0" standard="XWasser" test="true" version="0.9.2">
   <nachrichtenkopf.g2g>
     <identifikation.nachricht>
-      <nachrichtenUUID>a9945930-e958-4c3c-a1eb-067cdde2b7d9</nachrichtenUUID>
+      <nachrichtenUUID>54aa24ad-3035-43c4-842e-a963da3a5e33</nachrichtenUUID>
       <nachrichtentyp listURI="urn:xoev-de:xwasser:codeliste:nachrichtentyp" listVersionID="1">
         <code>2010</code>
       </nachrichtentyp>
-      <erstellungszeitpunkt>2025-07-15T15:50:55</erstellungszeitpunkt>
+      <erstellungszeitpunkt>2026-04-15T23:16:41</erstellungszeitpunkt>
     </identifikation.nachricht>
     <leser>
       <verzeichnisdienst listVersionID="">
@@ -26,12 +26,12 @@
   </nachrichtenkopf.g2g>
   <xwas:vorgang>
     <xwas:identifikationVorgang>
-      <xwas:vorgangsID>fb3f24d2-b17e-4334-9464-c9a7126baef5</xwas:vorgangsID>
+      <xwas:vorgangsID>9a95024a-f21e-4a3f-9ff8-5e426301dfce</xwas:vorgangsID>
     </xwas:identifikationVorgang>
     <xwas:vorgangType>
-      <xwas:untersuchungsplan id="untersuchungsplan-KD5c0com">
-        <xwas:untersuchungsplanID>6aa6b6ab-1027-4557-aef0-8448a2d69108</xwas:untersuchungsplanID>
-        <xwas:wasserversorgungsgebiet>wvg-DZScU5Js</xwas:wasserversorgungsgebiet>
+      <xwas:untersuchungsplan id="untersuchungsplan-eZDu3rMJ">
+        <xwas:untersuchungsplanID>e8a199d9-9c75-46cf-b609-54a1772349f4</xwas:untersuchungsplanID>
+        <xwas:wasserversorgungsgebiet>wvg-7DFB4lhq</xwas:wasserversorgungsgebiet>
         <xwas:jahr>2024</xwas:jahr>
         <xwas:jahr>2025</xwas:jahr>
         <xwas:wasserabgabeVorjahr>0</xwas:wasserabgabeVorjahr>
@@ -66,9 +66,9 @@
         <xwas:statusUntersuchungsplan listURI="urn:xoev-de:xwasser:codeliste:status-untersuchungsplan" listVersionID="2">
           <code>1010</code>
         </xwas:statusUntersuchungsplan>
-        <xwas:terminplan id="terminplan-BFZvJbI1">
-          <xwas:terminplanID>113bd18b-8167-4799-9d5c-f51052ce1810</xwas:terminplanID>
-          <xwas:datumZeitraum>2025-07-15T15:50:55</xwas:datumZeitraum>
+        <xwas:terminplan id="terminplan-5xFY3x6v">
+          <xwas:terminplanID>1e1a1bfc-0eaf-4909-bb1d-19f9ccebc59c</xwas:terminplanID>
+          <xwas:datumZeitraum>2026-04-15T23:16:41</xwas:datumZeitraum>
           <xwas:probennahmestelleKategorie listURI="urn:xoev-de:xwasser:codeliste:kategorie-probennahmestelle" listVersionID="1">
             <code>L</code>
           </xwas:probennahmestelleKategorie>
@@ -87,18 +87,18 @@
             <xwas:reduzierbarOhneRAU>false</xwas:reduzierbarOhneRAU>
           </xwas:zuUntersuchenderParameter>
         </xwas:terminplan>
-        <xwas:anlageNachTrinkwV id="antv-EHkxPl87">
+        <xwas:anlageNachTrinkwV id="antv-8JksuBeT">
           <xwas:anlageNachTrinkwVID></xwas:anlageNachTrinkwVID>
-          <xwas:zustaendigeBehoerdeID>behoerde-A3q7ZLWV</xwas:zustaendigeBehoerdeID>
+          <xwas:zustaendigeBehoerdeID>behoerde-4xc4JXTM</xwas:zustaendigeBehoerdeID>
           <xwas:artAnlage listURI="urn:xoev-de:xwasser:codeliste:art-trinkwasseranlage" listVersionID="1">
             <code>1010</code>
           </xwas:artAnlage>
           <xwas:nameDerAnlage></xwas:nameDerAnlage>
-          <xwas:wasserversorgungsgebiet id="wvg-DZScU5Js">
-            <xwas:wasserversorgungsgebietID>f5a860e6-9335-41a7-837d-004a5da59597</xwas:wasserversorgungsgebietID>
+          <xwas:wasserversorgungsgebiet id="wvg-7DFB4lhq">
+            <xwas:wasserversorgungsgebietID>5e51ab82-0144-4124-88b1-3dbd6767e215</xwas:wasserversorgungsgebietID>
             <xwas:nameWasserversorgungsgebiet></xwas:nameWasserversorgungsgebiet>
             <xwas:zustaendigeBehoerde>
-              <xwas:id>behoerde-CjN3h6jE</xwas:id>
+              <xwas:id>behoerde-6z8PdMrC</xwas:id>
               <xwas:typ>
                 <code></code>
               </xwas:typ>
@@ -118,7 +118,7 @@
                 </xwas:gueltigkeit>
               </xwas:behoerdenname>
             </xwas:zustaendigeBehoerde>
-            <xwas:datumDerEinrichtung>2025-07-15</xwas:datumDerEinrichtung>
+            <xwas:datumDerEinrichtung>2026-04-15</xwas:datumDerEinrichtung>
             <xwas:abgegebeneWassermenge>0</xwas:abgegebeneWassermenge>
             <xwas:anzahlVersorgtePersonenWVG>0</xwas:anzahlVersorgtePersonenWVG>
             <xwas:referenzjahrAngabenWVG>0</xwas:referenzjahrAngabenWVG>
@@ -130,25 +130,23 @@
             <xwas:vorgeschriebeneUntersuchungshaeufigkeitParameterB>0</xwas:vorgeschriebeneUntersuchungshaeufigkeitParameterB>
           </xwas:wasserversorgungsgebiet>
         </xwas:anlageNachTrinkwV>
-        <xwas:objekt id="obj-GdyIrJbT">
-          <xwas:objektID>48abb680-1e38-4088-8739-9f401644fc54</xwas:objektID>
+        <xwas:objekt id="obj-a1jw42pC">
+          <xwas:objektID>db31f13a-19db-43f1-b8cf-fef7a94a0672</xwas:objektID>
           <xwas:artObjekt listURI="urn:xoev-de:xwasser:codeliste:art-objekt" listVersionID="1">
             <code>1010</code>
           </xwas:artObjekt>
           <xwas:nameObjekt></xwas:nameObjekt>
-          <xwas:geokoordinatenObjekt>
-          </xwas:geokoordinatenObjekt>
-          <xwas:betreiber id="betreiber-IRXPEiep">
-            <xwas:betreiberID>fcbd6800-86fe-4a63-9268-8efc5132675c</xwas:betreiberID>
+          <xwas:betreiber id="betreiber-crzDN2CJ">
+            <xwas:betreiberID>d45d006b-18ad-4b31-a614-e804e77521fd</xwas:betreiberID>
             <xwas:artDerPerson>
-              <xwas:organisation id="organisation-H1sno4Ss">
+              <xwas:organisation id="organisation-bdKDjiKk">
               </xwas:organisation>
             </xwas:artDerPerson>
-            <xwas:objektID>obj-GdyIrJbT</xwas:objektID>
+            <xwas:objektID>obj-a1jw42pC</xwas:objektID>
           </xwas:betreiber>
         </xwas:objekt>
-        <xwas:probennahmestelle id="probennahmestelle-JJ9kQ334">
-          <xwas:probennahmestelleID>76bf132d-f645-445c-9628-6532ae30677d</xwas:probennahmestelleID>
+        <xwas:probennahmestelle id="probennahmestelle-dHQhhLYR">
+          <xwas:probennahmestelleID>b1cdc034-1ce4-45ae-84e8-f28a6dd357e9</xwas:probennahmestelleID>
           <xwas:nameProbennahmestelle>Probennahmestelle 1</xwas:nameProbennahmestelle>
           <xwas:kategorieProbennahmestelle listURI="urn:xoev-de:xwasser:codeliste:kategorie-probennahmestelle" listVersionID="1">
             <code>L</code>
@@ -170,12 +168,12 @@
             <code>1010</code>
           </xwas:auftraggeberart>
           <xwas:auftraggeber>
-            <xwas:organisation id="organisation-FrcLps3A">
+            <xwas:organisation id="organisation-9RbDBHIg">
             </xwas:organisation>
           </xwas:auftraggeber>
         </xwas:auftraggeber>
         <xwas:zustaendigeBehoerde>
-          <xwas:id>behoerde-A3q7ZLWV</xwas:id>
+          <xwas:id>behoerde-4xc4JXTM</xwas:id>
           <xwas:typ>
             <code></code>
           </xwas:typ>

--- a/tests/olb_report_signature_builder.json
+++ b/tests/olb_report_signature_builder.json
@@ -5,13 +5,13 @@
   "test": true,
   "nachrichtenkopf_g2g": {
     "identifikation_nachricht": {
-      "nachrichten_uuid": "9bd6a2ba-34f7-4e29-99cf-5fba73beab15",
+      "nachrichten_uuid": "5d039d44-54b2-4f93-bfa2-b29ec469d5a4",
       "nachrichten_typ": {
         "code": {
           "code": "2010"
         }
       },
-      "erstellungszeitpunkt": "2025-07-15T15:50:55"
+      "erstellungszeitpunkt": "2026-04-15T23:16:42"
     },
     "leser": {
       "verzeichnisdienst": {
@@ -37,7 +37,7 @@
   },
   "vorgang": {
     "identifikation_vorgang": {
-      "vorgangs_id": "8b0b7649-21f2-40ef-8541-bc6b0d9b45ff"
+      "vorgangs_id": "2208d398-f62e-4584-8450-9b929ca25303"
     },
     "vorgang_type": {
       "t": "OlbBericht",

--- a/tests/olb_report_signature_builder_test_result.xml
+++ b/tests/olb_report_signature_builder_test_result.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<xwas:vorgang.transportieren.2010 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/ ../schemas/V0_9_2/xwasser.xsd" xmlns:xwas="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/" produkt="XWasser Test" produkthersteller="H&amp;amp;D GmbH" produktversion="0.800.0" standard="XWasser" test="true" version="0.9.2">
+<xwas:vorgang.transportieren.2010 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/ ../schemas/V0_9_2/xwasser.xsd" xmlns:xwas="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/" produkt="XWasser Test" produkthersteller="H&amp;D GmbH" produktversion="0.800.0" standard="XWasser" test="true" version="0.9.2">
   <nachrichtenkopf.g2g>
     <identifikation.nachricht>
-      <nachrichtenUUID>9bd6a2ba-34f7-4e29-99cf-5fba73beab15</nachrichtenUUID>
+      <nachrichtenUUID>5d039d44-54b2-4f93-bfa2-b29ec469d5a4</nachrichtenUUID>
       <nachrichtentyp listURI="urn:xoev-de:xwasser:codeliste:nachrichtentyp" listVersionID="1">
         <code>2010</code>
       </nachrichtentyp>
-      <erstellungszeitpunkt>2025-07-15T15:50:55</erstellungszeitpunkt>
+      <erstellungszeitpunkt>2026-04-15T23:16:42</erstellungszeitpunkt>
     </identifikation.nachricht>
     <leser>
       <verzeichnisdienst listVersionID="">
@@ -26,7 +26,7 @@
   </nachrichtenkopf.g2g>
   <xwas:vorgang>
     <xwas:identifikationVorgang>
-      <xwas:vorgangsID>8b0b7649-21f2-40ef-8541-bc6b0d9b45ff</xwas:vorgangsID>
+      <xwas:vorgangsID>2208d398-f62e-4584-8450-9b929ca25303</xwas:vorgangsID>
     </xwas:identifikationVorgang>
     <xwas:vorgangType>
       <xwas:olb_bericht dokumentID="id12345">

--- a/tests/quality_report_builder.json
+++ b/tests/quality_report_builder.json
@@ -5,13 +5,13 @@
   "test": true,
   "nachrichtenkopf_g2g": {
     "identifikation_nachricht": {
-      "nachrichten_uuid": "bd2e99e1-f6b3-4ece-9f21-b441d5a58f54",
+      "nachrichten_uuid": "4b801e47-f7cd-4d4a-bbc4-500987520c00",
       "nachrichten_typ": {
         "code": {
           "code": "2010"
         }
       },
-      "erstellungszeitpunkt": "2025-07-15T15:50:55"
+      "erstellungszeitpunkt": "2026-04-15T23:16:43"
     },
     "leser": {
       "verzeichnisdienst": {
@@ -37,14 +37,14 @@
   },
   "vorgang": {
     "identifikation_vorgang": {
-      "vorgangs_id": "8bf2e3a0-cf60-4068-a7c7-bed962fbb82f"
+      "vorgangs_id": "d224d5cf-efb2-4b55-b31b-5790cc6bc8c7"
     },
     "vorgang_type": {
       "t": "Pruefbericht",
       "c": {
-        "pruefbericht_uuid": "2e192b46-0900-4a45-b0fd-e7aa054a62fb",
+        "pruefbericht_uuid": "143b695e-5128-47cc-9c28-807501f1325f",
         "versionsnummer": 1,
-        "auftragsnummer": "8b189ff3-70d3-4f42-983e-fe82f94abd65",
+        "auftragsnummer": "6b56528d-e1ab-4e3d-bd1d-c574db173093",
         "zustaendige_behoerde": [
           {
             "id": null,
@@ -68,7 +68,7 @@
         ],
         "probennahmestelle": [
           {
-            "probennahmestelle_id": "id-82449dc5-acf3-4281-8013-f7dd01c65969",
+            "probennahmestelle_id": "id-e4b809f0-1d1c-4994-90f5-aff5b897cb28",
             "objekt_id": "none",
             "wasserversorgungsgebiet_id": null,
             "probe": [],
@@ -97,20 +97,20 @@
             "angaben_alternative_id": null,
             "berichtspflichtig": null,
             "kommentar": null,
-            "id": "id-82449dc5-acf3-4281-8013-f7dd01c65969"
+            "id": "id-e4b809f0-1d1c-4994-90f5-aff5b897cb28"
           }
         ],
         "probe": [
           {
-            "probe_id": "67a8884c-ce7a-48be-81ef-04fee4d024d9",
-            "probennahmestelle": "id-82449dc5-acf3-4281-8013-f7dd01c65969",
+            "probe_id": "e66a6e32-ddf9-4623-89e1-ab5cdc176970",
+            "probennahmestelle": "id-e4b809f0-1d1c-4994-90f5-aff5b897cb28",
             "untersuchungsplan_id": null,
             "probennehmer": null,
             "titel_probe": null,
             "analyseergebnis_parameter": [
               {
-                "analyseergebnis_parameter_id": "10d4a157-8572-462f-b852-7263b2df1823",
-                "anschrift_id": "anschrift-01sK7ceh",
+                "analyseergebnis_parameter_id": "d3d0d490-3af4-4d1b-b5ed-e26777706e00",
+                "anschrift_id": "anschrift-fvkb1hPG",
                 "zugelassene_untersuchungsstelle": "wsu-1",
                 "akkreditierte_durchfuehrung_analyse": false,
                 "zugelassene_durchfuehrung_analyse": true,
@@ -164,7 +164,7 @@
             },
             "akkreditierte_durchfuehrung_der_probennahme": false,
             "ergaenzung_zum_medium": null,
-            "zeitpunkt_probennahme": "2025-07-15T15:50:55",
+            "zeitpunkt_probennahme": "2026-04-15T23:16:43",
             "probennahmeverfahren": [
               {
                 "code": "1010",
@@ -183,9 +183,9 @@
             ],
             "kommentar_zur_probennahme": null,
             "informationen_zum_probentransport": null,
-            "eingang_probe_bei_untersuchungsstelle": "2025-07-15T15:50:55",
-            "beginn_labortaetigkeit_analytik": "2025-07-15T15:50:55",
-            "abschluss_labortaetigkeit_analytik": "2025-07-15T15:50:55",
+            "eingang_probe_bei_untersuchungsstelle": "2026-04-15T23:16:43",
+            "beginn_labortaetigkeit_analytik": "2026-04-15T23:16:43",
+            "abschluss_labortaetigkeit_analytik": "2026-04-15T23:16:43",
             "konformitaetsbewertung_der_probe": {
               "code": "1010",
               "name": null
@@ -202,7 +202,7 @@
         ],
         "probennehmer": [
           {
-            "probennehmer_id": "924ba420-b7ef-40e9-920d-0810ac3c9759",
+            "probennehmer_id": "0ccecc96-5ddc-4ac9-a6ea-21a60f9c0cfe",
             "probennehmer": {
               "t": "NatuerlichePerson",
               "c": {
@@ -237,7 +237,7 @@
           "name": null
         },
         "auffaelligkeiten": [],
-        "zeitpunkt_validierung_pruefbericht": "2025-07-15T15:50:55",
+        "zeitpunkt_validierung_pruefbericht": "2026-04-15T23:16:43",
         "fuer_validierung_verantwortliche_person": [
           {
             "auskunftssperre": [],
@@ -327,7 +327,7 @@
             "typ": [],
             "staat": null,
             "verwaltungspolitische_kodierung": null,
-            "id": "anschrift-01sK7ceh"
+            "id": "anschrift-fvkb1hPG"
           }
         ],
         "gefahr_in_verzug": false,

--- a/tests/quality_report_builder_test_result.xml
+++ b/tests/quality_report_builder_test_result.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<xwas:vorgang.transportieren.2010 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/ ../schemas/V0_9_2/xwasser.xsd" xmlns:xwas="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/" produkt="XWasser Test" produkthersteller="H&amp;amp;D GmbH" produktversion="0.800.0" standard="XWasser" test="true" version="0.9.2">
+<xwas:vorgang.transportieren.2010 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/ ../schemas/V0_9_2/xwasser.xsd" xmlns:xwas="https://gitlab.opencode.de/akdb/xoev/xwasser/-/raw/main/V0_9_2/" produkt="XWasser Test" produkthersteller="H&amp;D GmbH" produktversion="0.800.0" standard="XWasser" test="true" version="0.9.2">
   <nachrichtenkopf.g2g>
     <identifikation.nachricht>
-      <nachrichtenUUID>bd2e99e1-f6b3-4ece-9f21-b441d5a58f54</nachrichtenUUID>
+      <nachrichtenUUID>4b801e47-f7cd-4d4a-bbc4-500987520c00</nachrichtenUUID>
       <nachrichtentyp listURI="urn:xoev-de:xwasser:codeliste:nachrichtentyp" listVersionID="1">
         <code>2010</code>
       </nachrichtentyp>
-      <erstellungszeitpunkt>2025-07-15T15:50:55</erstellungszeitpunkt>
+      <erstellungszeitpunkt>2026-04-15T23:16:43</erstellungszeitpunkt>
     </identifikation.nachricht>
     <leser>
       <verzeichnisdienst listVersionID="">
@@ -26,20 +26,20 @@
   </nachrichtenkopf.g2g>
   <xwas:vorgang>
     <xwas:identifikationVorgang>
-      <xwas:vorgangsID>8bf2e3a0-cf60-4068-a7c7-bed962fbb82f</xwas:vorgangsID>
+      <xwas:vorgangsID>d224d5cf-efb2-4b55-b31b-5790cc6bc8c7</xwas:vorgangsID>
     </xwas:identifikationVorgang>
     <xwas:vorgangType>
       <xwas:pruefbericht id="pruefbericht-1">
-        <xwas:pruefberichtUUID>2e192b46-0900-4a45-b0fd-e7aa054a62fb</xwas:pruefberichtUUID>
+        <xwas:pruefberichtUUID>143b695e-5128-47cc-9c28-807501f1325f</xwas:pruefberichtUUID>
         <xwas:versionsnummer>1</xwas:versionsnummer>
-        <xwas:auftragsnummer>8b189ff3-70d3-4f42-983e-fe82f94abd65</xwas:auftragsnummer>
+        <xwas:auftragsnummer>6b56528d-e1ab-4e3d-bd1d-c574db173093</xwas:auftragsnummer>
         <xwas:zustaendigeBehoerde>
           <xwas:laenderkuerzel listURI="urn:xoev-de:xwasser:codeliste:laenderkennzeichen" listVersionID="1">
             <code>DEBY</code>
           </xwas:laenderkuerzel>
         </xwas:zustaendigeBehoerde>
-        <xwas:probennahmestelle id="id-82449dc5-acf3-4281-8013-f7dd01c65969">
-          <xwas:probennahmestelleID>id-82449dc5-acf3-4281-8013-f7dd01c65969</xwas:probennahmestelleID>
+        <xwas:probennahmestelle id="id-e4b809f0-1d1c-4994-90f5-aff5b897cb28">
+          <xwas:probennahmestelleID>id-e4b809f0-1d1c-4994-90f5-aff5b897cb28</xwas:probennahmestelleID>
           <xwas:objektID>none</xwas:objektID>
           <xwas:nameProbennahmestelle></xwas:nameProbennahmestelle>
           <xwas:kategorieProbennahmestelle listURI="urn:xoev-de:xwasser:codeliste:kategorie-probennahmestelle" listVersionID="1">
@@ -57,11 +57,11 @@
           </xwas:mediumAnDerProbennahmestelle>
         </xwas:probennahmestelle>
         <xwas:probe id="probe-1">
-          <xwas:probeID>67a8884c-ce7a-48be-81ef-04fee4d024d9</xwas:probeID>
-          <xwas:probennahmestelle>id-82449dc5-acf3-4281-8013-f7dd01c65969</xwas:probennahmestelle>
+          <xwas:probeID>e66a6e32-ddf9-4623-89e1-ab5cdc176970</xwas:probeID>
+          <xwas:probennahmestelle>id-e4b809f0-1d1c-4994-90f5-aff5b897cb28</xwas:probennahmestelle>
           <xwas:analyseergebnisParameter id="param-1">
-            <xwas:analyseergebnisParameterID>10d4a157-8572-462f-b852-7263b2df1823</xwas:analyseergebnisParameterID>
-            <xwas:anschriftID>anschrift-01sK7ceh</xwas:anschriftID>
+            <xwas:analyseergebnisParameterID>d3d0d490-3af4-4d1b-b5ed-e26777706e00</xwas:analyseergebnisParameterID>
+            <xwas:anschriftID>anschrift-fvkb1hPG</xwas:anschriftID>
             <xwas:zugelasseneUntersuchungsstelle>wsu-1</xwas:zugelasseneUntersuchungsstelle>
             <xwas:akkreditierteDurchfuehrungAnalyse>false</xwas:akkreditierteDurchfuehrungAnalyse>
             <xwas:zugelasseneDurchfuehrungAnalyse>true</xwas:zugelasseneDurchfuehrungAnalyse>
@@ -92,7 +92,7 @@
             <code>1010</code>
           </xwas:medium>
           <xwas:akkreditierteDurchfuehrungDerProbennahme>false</xwas:akkreditierteDurchfuehrungDerProbennahme>
-          <xwas:zeitpunktProbennahme>2025-07-15T15:50:55</xwas:zeitpunktProbennahme>
+          <xwas:zeitpunktProbennahme>2026-04-15T23:16:43</xwas:zeitpunktProbennahme>
           <xwas:probennahmeverfahren listURI="urn:xoev-de:xwasser:codeliste:probennahmeverfahren" listVersionID="1">
             <code>1010</code>
           </xwas:probennahmeverfahren>
@@ -100,16 +100,16 @@
             <code>9020</code>
           </xwas:probenentnahmegeraet>
           <xwas:konservierungDerProbe>1020</xwas:konservierungDerProbe>
-          <xwas:eingangProbeBeiUntersuchungsstelle>2025-07-15T15:50:55</xwas:eingangProbeBeiUntersuchungsstelle>
-          <xwas:beginnLabortaetigkeitAnalytik>2025-07-15T15:50:55</xwas:beginnLabortaetigkeitAnalytik>
-          <xwas:abschlussLabortaetigkeitAnalytik>2025-07-15T15:50:55</xwas:abschlussLabortaetigkeitAnalytik>
+          <xwas:eingangProbeBeiUntersuchungsstelle>2026-04-15T23:16:43</xwas:eingangProbeBeiUntersuchungsstelle>
+          <xwas:beginnLabortaetigkeitAnalytik>2026-04-15T23:16:43</xwas:beginnLabortaetigkeitAnalytik>
+          <xwas:abschlussLabortaetigkeitAnalytik>2026-04-15T23:16:43</xwas:abschlussLabortaetigkeitAnalytik>
           <xwas:konformitaetsbewertungDerProbe listURI="urn:xoev-de:xwasser:codeliste:probenbewertung" listVersionID="1">
             <code>1010</code>
           </xwas:konformitaetsbewertungDerProbe>
           <xwas:probeID_ausLabor></xwas:probeID_ausLabor>
         </xwas:probe>
         <xwas:probennehmer id="probennehmer-1">
-          <xwas:probennehmerID>924ba420-b7ef-40e9-920d-0810ac3c9759</xwas:probennehmerID>
+          <xwas:probennehmerID>0ccecc96-5ddc-4ac9-a6ea-21a60f9c0cfe</xwas:probennehmerID>
           <xwas:probennehmer>
             <xwas:natuerlichePerson>
             </xwas:natuerlichePerson>
@@ -121,7 +121,7 @@
         <xwas:gesamtbewertung listURI="urn:xoev-de:xwasser:codeliste:gesamtbewertung" listVersionID="2">
           <code>1010</code>
         </xwas:gesamtbewertung>
-        <xwas:zeitpunktValidierungPruefbericht>2025-07-15T15:50:55</xwas:zeitpunktValidierungPruefbericht>
+        <xwas:zeitpunktValidierungPruefbericht>2026-04-15T23:16:43</xwas:zeitpunktValidierungPruefbericht>
         <xwas:fuerValidierungVerantwortlichePerson id="bevollmaechtigter-1">
         </xwas:fuerValidierungVerantwortlichePerson>
         <xwas:freigabeUebermittlungBetreiber>false</xwas:freigabeUebermittlungBetreiber>
@@ -144,7 +144,7 @@
         <xwas:beauftragteUntersuchungsstelle id="wsu-1">
           <xwas:zugelasseneUntersuchungsstelleID></xwas:zugelasseneUntersuchungsstelleID>
         </xwas:beauftragteUntersuchungsstelle>
-        <xwas:ortDerLabortaetigkeiten id="anschrift-01sK7ceh">
+        <xwas:ortDerLabortaetigkeiten id="anschrift-fvkb1hPG">
           <xwas:strasse>strasse</xwas:strasse>
           <xwas:hausnummer>hausnummer</xwas:hausnummer>
           <xwas:postleitzahl>postleitzahl</xwas:postleitzahl>

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "xtask"
+edition.workspace = true
+version.workspace = true
+description = """
+XOEV XWasser XML Standard: XTask
+"""
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[dependencies]
+encoding_rs.workspace = true
+json-spanned-value = "0.2.2"
+raxb.workspace = true
+reqwest = { version = "0.12.24", features = ["blocking", "json"] }
+serde.workspace = true
+xflags = "0.3.2"
+zip = "6.0.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,358 @@
+use std::{
+    fs::{create_dir_all, remove_dir_all},
+    io::{self, Cursor, Read},
+    path::Path,
+    process::{Command, ExitCode},
+};
+
+use raxb::quick_xml::events::Event;
+
+mod flags {
+    xflags::xflags! {
+        cmd x-task {
+            default cmd set-version {
+                required --version version: String
+            }
+            cmd get-version {}
+            cmd patch {}
+            cmd release {
+                optional --no-tag
+                optional --no-push
+            }
+        }
+    }
+}
+
+impl flags::XTask {
+    fn process(self) -> Result<(), Box<dyn std::error::Error>> {
+        match self.subcommand {
+            flags::XTaskCmd::SetVersion(flags::SetVersion { version }) => {
+                set_version(&version)?;
+                fetch_codelists(&version)?;
+            }
+            flags::XTaskCmd::GetVersion(_) => {
+                print!("{}", current_version()?);
+            }
+            flags::XTaskCmd::Patch(_) => {
+                patch_version(&get_meta_version()?)?;
+            }
+            flags::XTaskCmd::Release(flags::Release { no_tag, no_push }) => {
+                release(no_tag, no_push)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn fetch_codelists(version: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let version = version
+        .split('+')
+        .nth(1)
+        .expect("version of XWasser after + sign");
+    let file_path_version = format!("v{}", version.replace('.', "_"));
+    let url = format!(
+        "https://www.xrepository.de/api/version_standard/urn:xoev-de:lgl:standard:xwasser_{version}/genutzteAktuelleCodelisten"
+    );
+    println!("Fetching codelists from {}", url);
+    let response = reqwest::blocking::get(url)?.error_for_status()?.bytes()?;
+    let zip_data = Cursor::new(response);
+
+    let mut zip_file = zip::ZipArchive::new(zip_data)?;
+    let target_dir = Path::new("crates/codelists/data").join(file_path_version.to_uppercase());
+    if target_dir.exists() {
+        remove_dir_all(&target_dir)?;
+    }
+    if !target_dir.exists() {
+        create_dir_all(&target_dir)?;
+    }
+    for i in 0..zip_file.len() {
+        let mut file = zip_file.by_index(i)?;
+        let filename = target_dir.join(file.name());
+        println!("Extracting {}", filename.display());
+        if matches!(filename.extension(), Some(ext) if ext == "xml") {
+            let mut data = Vec::new();
+            file.read_to_end(&mut data)?;
+            let mut rdr = raxb::quick_xml::reader::Reader::from_reader(std::io::Cursor::new(&data));
+            let mut buf = Vec::new();
+            let saved = loop {
+                match rdr.read_event_into(&mut buf) {
+                    Ok(Event::Decl(decl)) => match decl.encoding() {
+                        Some(Ok(encoding)) => {
+                            if encoding.as_ref() == b"ISO-8859-1" {
+                                let encoder = encoding_rs::Encoding::for_label(b"iso-8859-1")
+                                    .ok_or(String::from("unknown encoding ISO_8859_1"))?;
+                                let (result, _) = encoder.decode_with_bom_removal(&data);
+                                eprintln!(
+                                    "Converted encoding from ISO-8859-1 to UTF-8 for {}",
+                                    filename.display()
+                                );
+                                let s = result.replace("ISO-8859-1", "UTF-8");
+                                std::fs::write(&filename, s.as_bytes())?;
+                                break true;
+                            }
+                        }
+                        _ => break false,
+                    },
+                    Err(err) => {
+                        eprintln!("{err:#?}");
+                        std::process::exit(1);
+                    }
+                    _ => {
+                        break false;
+                    }
+                }
+            };
+            if !saved {
+                std::fs::write(&filename, data)?;
+            }
+        } else {
+            let mut output = std::fs::File::create(filename)?;
+            io::copy(&mut file, &mut output)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    let flags = flags::XTask::from_env_or_exit();
+    match flags.process() {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn current_version() -> Result<String, String> {
+    let output = Command::new("cargo")
+        .arg("pkgid")
+        .output()
+        .expect("Failed to get current version using `cargo version`");
+
+    if output.status.success() {
+        let version =
+            String::from_utf8(output.stdout).map_err(|_| "Failed to parse version".to_string())?;
+        version
+            .trim()
+            .split('@')
+            .nth(1)
+            .map(str::to_string)
+            .ok_or_else(|| format!("Failed to parse version: {version}"))
+    } else {
+        Err("Failed to get current version".to_string())
+    }
+}
+
+fn get_meta_version() -> Result<String, String> {
+    current_version().and_then(|version| {
+        version
+            .split('+')
+            .nth(1)
+            .map(str::to_string)
+            .ok_or_else(|| format!("Could not get metainfo from {version}"))
+    })
+}
+
+fn set_version(version: &str) -> Result<(), String> {
+    println!("Setting version to {version}");
+    if Command::new("cargo")
+        .arg("set-version")
+        .arg("--workspace")
+        .arg(version)
+        .status()
+        .expect("Failed to set version using `cargo set-version`")
+        .success()
+    {
+        set_package_json_versions(version)?;
+        println!("Version set successfully");
+    } else {
+        println!("Failed to set version");
+        return Err("Failed to set version".to_string());
+    }
+    Ok(())
+}
+
+fn patch_version(metadata: &str) -> Result<(), String> {
+    println!("Patching version");
+    if Command::new("cargo")
+        .arg("set-version")
+        .arg("--workspace")
+        .arg("--bump")
+        .arg("patch")
+        .arg("--metadata")
+        .arg(metadata)
+        .status()
+        .expect("Failed to set version using `cargo set-version`")
+        .success()
+    {
+        let version = current_version()?;
+        set_package_json_versions(&version)?;
+        println!("Version set successfully");
+    } else {
+        println!("Failed to set version");
+        return Err("Failed to set version".to_string());
+    }
+    Ok(())
+}
+
+fn set_package_json_versions(version: &str) -> Result<(), String> {
+    // For npm packages, strip everything after '+' to comply with SemVer
+    // e.g., "1.0.0+1.0.0" -> "1.0.0"
+    let npm_version = version.split('+').next().unwrap_or(version);
+
+    for json_file in ["package.json", "package.tmp.json", "package.tmp.web.json"] {
+        set_json_version(json_file, npm_version)?;
+    }
+    Ok(())
+}
+
+fn set_json_version(json_file: &str, new_version: &str) -> Result<(), String> {
+    println!("Setting version in {json_file} to {new_version}");
+    use json_spanned_value::Spanned;
+    #[derive(serde::Deserialize)]
+    struct PackageJson {
+        version: Spanned<String>,
+    }
+    let mut json_data = std::fs::read_to_string(json_file)
+        .map_err(|err| format!("Failed to read {json_file}: {err}"))?;
+
+    let PackageJson { version } = json_spanned_value::from_str(&json_data)
+        .map_err(|err| format!("Failed to parse {json_file}: {err}"))?;
+
+    let range = version.start() + 1..version.end() - 1;
+    json_data.replace_range(range, new_version);
+
+    std::fs::write(json_file, json_data)
+        .map_err(|err| format!("Failed to write {json_file}: {err}"))?;
+    Ok(())
+}
+
+fn release(no_tag: bool, no_push: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let version = current_version()?;
+    cargo_update()?;
+    cargo_build()?;
+    git_add()?;
+    git_commit(&format!("release {version}"))?;
+    if !no_tag {
+        git_tag(&format!("v{}", version))?;
+    }
+    if !no_push {
+        git_push()?;
+        if !no_tag {
+            git_push_tag()?;
+        }
+    }
+    Ok(())
+}
+
+fn git_add() -> Result<(), String> {
+    let status = std::process::Command::new("git")
+        .arg("add")
+        .arg(".")
+        .status()
+        .expect("Failed to add changes using `git add`")
+        .success();
+    if status {
+        println!("Changes added successfully");
+    } else {
+        println!("Failed to add changes");
+        return Err("Failed to add changes".to_string());
+    }
+    Ok(())
+}
+
+fn cargo_update() -> Result<(), String> {
+    let status = std::process::Command::new("cargo")
+        .arg("update")
+        .status()
+        .expect("Failed to update dependencies using `cargo update`")
+        .success();
+    if status {
+        println!("Dependencies updated successfully");
+    } else {
+        println!("Failed to update dependencies");
+        return Err("Failed to update dependencies".to_string());
+    }
+    Ok(())
+}
+
+fn cargo_build() -> Result<(), String> {
+    let status = std::process::Command::new("cargo")
+        .arg("build")
+        .status()
+        .expect("Failed to build using `cargo build`")
+        .success();
+    if status {
+        println!("Build successful");
+    } else {
+        println!("Build failed");
+        return Err("Build failed".to_string());
+    }
+    Ok(())
+}
+
+fn git_commit(message: &str) -> Result<(), String> {
+    let status = std::process::Command::new("git")
+        .arg("commit")
+        .arg("-m")
+        .arg(message)
+        .status()
+        .expect("Failed to commit changes using `git commit`")
+        .success();
+    if status {
+        println!("Changes committed successfully");
+    } else {
+        println!("Failed to commit changes");
+        return Err("Failed to commit changes".to_string());
+    }
+    Ok(())
+}
+
+fn git_tag(tag: &str) -> Result<(), String> {
+    let status = std::process::Command::new("git")
+        .arg("tag")
+        .arg(tag)
+        .status()
+        .expect("Failed to tag changes using `git tag`")
+        .success();
+    if status {
+        println!("Changes tagged successfully");
+    } else {
+        println!("Failed to tag changes");
+        return Err("Failed to tag changes".to_string());
+    }
+    Ok(())
+}
+
+fn git_push() -> Result<(), String> {
+    let status = std::process::Command::new("git")
+        .arg("push")
+        .status()
+        .expect("Failed to push changes using `git push`")
+        .success();
+    if status {
+        println!("Changes pushed successfully");
+    } else {
+        println!("Failed to push changes");
+        return Err("Failed to push changes".to_string());
+    }
+    Ok(())
+}
+
+fn git_push_tag() -> Result<(), String> {
+    let status = std::process::Command::new("git")
+        .arg("push")
+        .arg("--tag")
+        .status()
+        .expect("Failed to push changes using `git push --tags`")
+        .success();
+    if status {
+        println!("Changes pushed successfully");
+    } else {
+        println!("Failed to push changes");
+        return Err("Failed to push changes".to_string());
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Update raxb, raxb-validate, raxb-xmlschema, raxb-xmlschema-build from 0.4.7 to 0.6.0 for compatibility with XWasser 1.0.0
- Add xtask for build automation (cherry-picked from main)
- Regenerate test fixtures

## Target Version
v0.902.1+0.9.2 (Z bump for internal dependency update per versioning scheme)

## References
- Closes #77